### PR TITLE
update to v0.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ from setuptools import setup
 
 setup(
     name='GCR',
-    version='0.5.1',
+    version='0.6.0',
     description='Generic Catalog Reader: A common reader interface for accessing generic catalogs',
     url='https://github.com/yymao/generic-catalog-reader',
-    download_url='https://github.com/yymao/generic-catalog-reader/archive/v0.5.1.zip',
+    download_url='https://github.com/yymao/generic-catalog-reader/archive/v0.6.0.zip',
     author='Yao-Yuan Mao',
     author_email='yymao.astro@gmail.com',
     maintainer='Yao-Yuan Mao',


### PR DESCRIPTION
* new method: `get_quantity_info()`
* new method: `get_catalog_info()`, which replaces `get_input_kwargs()`
* `get_input_kwargs()` is now deprecated.
* new argument `with_info` in `list_all_quantities()` and `list_all_native_quantities()`