### PR TITLE
Update v0.7.0

### DIFF
--- a/GCR.py
+++ b/GCR.py
@@ -2,7 +2,7 @@
 Contains the base class for a generic catalog (BaseGenericCatalog).
 """
 __all__ = ['BaseGenericCatalog', 'dict_to_numpy_array', 'GCRQuery']
-__version__ = '0.6.4'
+__version__ = '0.7.0'
 __author__ = 'Yao-Yuan Mao'
 
 import warnings

--- a/GCR.py
+++ b/GCR.py
@@ -483,8 +483,22 @@ class BaseGenericCatalog(object):
         return native_quantities_loaded[modifier]
 
 
+    @staticmethod
+    def _obtain_native_data_dict(native_quantities_needed, native_quantity_getter):
+        """
+        This method can be overwritten if `native_quantity_getter` has a
+        different behavior, for example, if `native_quantity_getter` can
+        retrive multiple quantities at once, this method can return
+        ```python
+        dict(zip(native_quantities_needed, native_quantity_getter(native_quantities_needed)))
+        ```
+        """
+        return {q: native_quantity_getter(q) for q in native_quantities_needed}
+
+
     def _load_quantities(self, quantities, native_quantity_getter):
-        native_data = {q: native_quantity_getter(q) for q in self._translate_quantities(quantities)}
+        native_quantities_needed = self._translate_quantities(quantities)
+        native_data = self._obtain_native_data_dict(native_quantities_needed, native_quantity_getter)
         return {q: self._assemble_quantity(q, native_data) for q in quantities}
 
 


### PR DESCRIPTION
This PR updates GCR to v0.7.0 for two major changes:
- use `GCRQuery` to process native filters
- separate method `_obtain_native_data_dict` from `_load_quantities`