### PR TITLE
make concatenate_1d work with masked arrays

### DIFF
--- a/GCR/utils.py
+++ b/GCR/utils.py
@@ -36,5 +36,5 @@ def concatenate_1d(arrays):
     if len(arrays) == 1:
         return np.asanyarray(arrays[0])
     if any(map(np.ma.is_masked, arrays)):
-        np.ma.concatenate(arrays)
+        return np.ma.concatenate(arrays)
     return np.concatenate(arrays)

--- a/GCR/utils.py
+++ b/GCR/utils.py
@@ -27,8 +27,14 @@ def dict_to_numpy_array(d):
     return fromarrays(d.values(), np.dtype([(str(k), v.dtype) for k, v in d.items()]))
 
 def concatenate_1d(arrays):
+    """
+    Concatenate 1D numpy arrays.
+    Similar to np.concatenate but work with empty input and masked arrays.
+    """
     if len(arrays) == 0:
         return np.array([])
     if len(arrays) == 1:
-        return np.asarray(arrays[0])
+        return np.asanyarray(arrays[0])
+    if any(map(np.ma.is_masked, arrays)):
+        np.ma.concatenate(arrays)
     return np.concatenate(arrays)

--- a/GCR/version.py
+++ b/GCR/version.py
@@ -1,2 +1,2 @@
 """package version"""
-__version__ = '0.8.6'
+__version__ = '0.8.7'


### PR DESCRIPTION
This PR fixes a bug where `concatenate_1d` does not work with masked arrays