### PR TITLE
Always return masked array when matching IDs in composite catalogs

### DIFF
--- a/GCR/composite.py
+++ b/GCR/composite.py
@@ -230,8 +230,7 @@ class CompositeCatalog(BaseGenericCatalog):
 
             for q in native_quantities_needed_dict[catalog.identifier]:
                 data_this = catalog.cache[q][matching_idx]
-                if not_matched_mask.any():
-                    data_this = np.ma.array(data_this, mask=not_matched_mask)
+                data_this = np.ma.array(data_this, mask=not_matched_mask)
                 data[(catalog.identifier, q)] = data_this
 
         return data

--- a/GCR/version.py
+++ b/GCR/version.py
@@ -1,2 +1,2 @@
 """package version"""
-__version__ = '0.8.8'
+__version__ = '0.9.0'

--- a/GCR/version.py
+++ b/GCR/version.py
@@ -1,2 +1,2 @@
 """package version"""
-__version__ = '0.9.0'
+__version__ = '0.8.9'


### PR DESCRIPTION
From the suggsition in https://github.com/LSSTDESC/gcr-catalogs/issues/400

Note that this only changes the behavior of composite catalogs that use IDs to match the entries. For composite catalogs that matches the format, there's not need to mask any entry and hence still returns unmasked entries. 