### PR TITLE
Set default matching_by_column and matching_column_in_main

### DIFF
--- a/GCR/composite.py
+++ b/GCR/composite.py
@@ -82,6 +82,7 @@ class CompositeSpecs(object):
 
         self.matching_partition = bool(matching_partition)
         self.matching_row_order = bool(matching_row_order)
+        self.matching_by_column = self.matching_column_in_main = None
         if matching_by_column:
             self.set_matching_column(matching_by_column, matching_column_in_main, matching_partition)
 

--- a/GCR/version.py
+++ b/GCR/version.py
@@ -1,3 +1,3 @@
 """package version"""
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'


### PR DESCRIPTION
This PR fixes the error mentioned in https://github.com/LSSTDESC/gcr-catalogs/pull/513#issuecomment-743540619. Thanks to @evevkovacs for noticing it. 