### PR TITLE
Improve get_quantity_info for composites and aliases

### DIFF
--- a/GCR/base.py
+++ b/GCR/base.py
@@ -185,7 +185,14 @@ class BaseGenericCatalog(object):
         Get information of a certain quantity.
         If *key* is `None`, return the full dict for that quantity.
         """
-        d = self._get_quantity_info_dict(quantity, default if key is None else dict())
+        d = self._get_quantity_info_dict(quantity, default=None)
+        if d is None and quantity in self._quantity_modifiers:
+            native = self._quantity_modifiers[quantity]
+            if native:
+                d = self._get_quantity_info_dict(native, default=None)
+
+        if d is None:
+            return default
 
         if key is None:
             return d

--- a/GCR/composite.py
+++ b/GCR/composite.py
@@ -398,7 +398,7 @@ class CompositeCatalog(BaseGenericCatalog):
             except KeyError:
                 pass
             else:
-                return cat.instance._get_quantity_info_dict(q, default=default)
+                return cat.instance.get_quantity_info(q, default=default)
         return default
 
     def _get_catalog_by_id(self, identifier):

--- a/GCR/composite.py
+++ b/GCR/composite.py
@@ -390,8 +390,16 @@ class CompositeCatalog(BaseGenericCatalog):
         return getattr(self.main, name)
 
     def _get_quantity_info_dict(self, quantity, default=None):
-        cat_id, q = self._quantity_modifiers.get(quantity)
-        return self._get_catalog_by_id(cat_id).instance._get_quantity_info_dict(q, default=default)
+        native_q = self._quantity_modifiers.get(quantity)
+        if isinstance(native_q, tuple) and len(native_q) == 2:
+            cat_id, q = native_q
+            try:
+                cat = self._get_catalog_by_id(cat_id)
+            except KeyError:
+                pass
+            else:
+                return cat.instance._get_quantity_info_dict(q, default=default)
+        return default
 
     def _get_catalog_by_id(self, identifier):
         for cat in self._catalogs:

--- a/GCR/version.py
+++ b/GCR/version.py
@@ -1,3 +1,3 @@
 """package version"""
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'


### PR DESCRIPTION
This PR improves the behavior of `get_quantity_info` for composite catalogs and quantity aliases. 

For composite catalogs, `get_quantity_info` will now behave like that for regular catalogs, i.e., returning `default` when an unknown quantity is supplied as argument. 

For quantity aliases, `get_quantity_info` will return the info for the native quantity in the case of simply alias. If the modifier involves further calculation, the behavior remains the same (i.e., returning `default` if quantity is not available in `_get_quantity_info_dict`.