### PR TITLE
MPI compatibility 

### DIFF
--- a/GCR/base.py
+++ b/GCR/base.py
@@ -39,7 +39,7 @@ class BaseGenericCatalog(object):
         # to check if all native quantities in the modifiers are present
         self._check_quantities_exist(self.list_all_quantities(True), raise_exception=False)
 
-    def get_quantities(self, quantities, filters=None, native_filters=None, return_iterator=False):
+    def get_quantities(self, quantities, filters=None, native_filters=None, return_iterator=False, rank=0, size=1):
         """
         Fetch quantities from this catalog.
 
@@ -66,7 +66,7 @@ class BaseGenericCatalog(object):
         filters = self._preprocess_filters(filters)
         native_filters = self._preprocess_native_filters(native_filters)
 
-        it = self._get_quantities_iter(quantities, filters, native_filters)
+        it = self._get_quantities_iter(quantities, filters, native_filters, rank, size)
 
         if return_iterator:
             return it
@@ -464,8 +464,8 @@ class BaseGenericCatalog(object):
         native_data = self._obtain_native_data_dict(native_quantities_needed, native_quantity_getter)
         return {q: self._assemble_quantity(q, native_data) for q in quantities}
 
-    def _get_quantities_iter(self, quantities, filters, native_filters):
-        for native_quantity_getter in self._iter_native_dataset(native_filters):
+    def _get_quantities_iter(self, quantities, filters, native_filters, rank, size):
+        for native_quantity_getter in self._iter_native_dataset(native_filters, rank, size):
             data = self._load_quantities(quantities.union(set(filters.variable_names)),
                                          native_quantity_getter)
             data = filters.filter(data)
@@ -497,7 +497,7 @@ class BaseGenericCatalog(object):
         """
         raise NotImplementedError
 
-    def _iter_native_dataset(self, native_filters=None):
+    def _iter_native_dataset(self, native_filters=None, rank=0, size=1):
         """
         To be implemented by subclass.
         Must be a generator.

--- a/GCR/composite.py
+++ b/GCR/composite.py
@@ -371,8 +371,13 @@ class CompositeCatalog(BaseGenericCatalog):
 
     def _iter_native_dataset(self, native_filters=None, rank=0, size=1):
         identifiers = tuple((cat.identifier for cat in self._catalogs))
+        count = 0
         for getters in zip(*(cat.get_data_iterator(native_filters, rank, size) for cat in self._catalogs)):
-            yield dict(zip(identifiers, getters))
+            if (count%size==rank):
+                count += 1
+                yield dict(zip(identifiers, getters))
+            else:
+                count +=1
 
     def __getattr__(self, name):
         attr_found = False

--- a/GCR/version.py
+++ b/GCR/version.py
@@ -1,3 +1,3 @@
 """package version"""
 
-__version__ = '0.9.2'
+__version__ = '0.9.3'


### PR DESCRIPTION
This allows for MPI compatibility by allowing optional rank and size arguments to reading functions, which restricts the data segments to divide them roughly evenly between the ranks. A version update to  0.9.3 is also given to allow checking  for this functionality. There are no additional dependencies, and this should be fully backwards compatible with all earlier GCR versions. Both the base reader and composite catalog reader have been updated. 